### PR TITLE
Fix an off-by-one in TranslateDeviceName()

### DIFF
--- a/source/application/wintaser.cpp
+++ b/source/application/wintaser.cpp
@@ -371,7 +371,7 @@ static std::wstring TranslateDeviceName(const std::wstring& filename)
                         {
                             return L"";
                         }
-                        wcsncpy(temp_str, temp_file, len);
+                        wcsncpy(temp_str, temp_file, len + 1);
                         break;
                     }
                 }


### PR DESCRIPTION
If you have too many drives (how many depends on the filename passed into this function) then with a probablility of 2/3 the function would return a filename with extra characters in the end. Since no file open success validation was done in `DbgHelp::LoadSymbols()`, this caused a crash (which is great since otherwise it'd look like symbols not loading for random files).