### PR TITLE
Add support for ptrs to types with unknown size

### DIFF
--- a/source/application/DbgHelp/DbgHelpStackWalkCallback.cpp
+++ b/source/application/DbgHelp/DbgHelpStackWalkCallback.cpp
@@ -192,6 +192,30 @@ namespace
                             return DbgHelpPointerType(DbgHelpUnknownType(underlying_length), length);
                         }
                     }
+                    else
+                    {
+                        /*
+                         * The underlying type has unknown length. Perhaps we can at least retrieve the name.
+                         *
+                         * TODO: The only case of this I stumbled upon so far is SymTagFunctionType.
+                         *       It doesn't have a name, but it can be printed. This requires more work though.
+                         * -- YaLTeR
+                         */
+                        std::optional<std::wstring> name;
+
+                        DWORD underlying_type_tag;
+                        if (underlying_type->get_symTag(&underlying_type_tag) == S_OK)
+                        {
+                            BSTR name_bstr;
+                            if (type_info->get_name(&name_bstr) == S_OK)
+                            {
+                                name = name_bstr;
+                                SysFreeString(name_bstr);
+                            }
+                        }
+
+                        return DbgHelpPointerType(DbgHelpUnknownUnsizedType(name), length);
+                    }
                 }
             }
             break;

--- a/source/application/DbgHelp/DbgHelpTypes.h
+++ b/source/application/DbgHelp/DbgHelpTypes.h
@@ -137,6 +137,22 @@ public:
 };
 
 /*
+ * An unknown type with an unknown size. Might have an available name.
+ */
+class DbgHelpUnknownUnsizedType
+{
+public:
+    const std::optional<std::wstring> m_name;
+
+    DbgHelpUnknownUnsizedType(std::optional<std::wstring> name = std::nullopt) : m_name(name) {}
+
+    std::wstring GetName() const
+    {
+        return m_name.value_or(L"unknown"s);
+    }
+};
+
+/*
  * An enum of either a basic type or an unknown type.
  */
 class DbgHelpEnumType
@@ -180,7 +196,10 @@ public:
 class DbgHelpPointerType
 {
 public:
-    const std::variant<DbgHelpBasicType, DbgHelpUnknownType, DbgHelpEnumType> m_underlying_type;
+    const std::variant<DbgHelpBasicType,
+                       DbgHelpUnknownType,
+                       DbgHelpEnumType,
+                       DbgHelpUnknownUnsizedType> m_underlying_type;
 
     /*
      * Size of the pointer type (differs between 32-bit and 64-bit targets).
@@ -192,6 +211,8 @@ public:
     DbgHelpPointerType(DbgHelpUnknownType underlying_type, size_t size)
         : m_underlying_type(underlying_type), m_size(size) {}
     DbgHelpPointerType(DbgHelpEnumType underlying_type, size_t size)
+        : m_underlying_type(underlying_type), m_size(size) {}
+    DbgHelpPointerType(DbgHelpUnknownUnsizedType underlying_type, size_t size)
         : m_underlying_type(underlying_type), m_size(size) {}
 
     std::wstring GetName() const


### PR DESCRIPTION
This changes `unknown * lpStartAddress = ` to `unknown * lpStartAddress = 0x1001B120`. Now as specified in the TODO comment, it's possible to print the function pointer type (so `unknown *` would become something like `DWORD (*)(LPVOID)`) as happens in this case, but this would require more work coming up with how to represent it and get cleanly. Should I do that for this PR?